### PR TITLE
Make Python plugins compatible with Python 3

### DIFF
--- a/ftplugin/fortran_block.vim
+++ b/ftplugin/fortran_block.vim
@@ -45,7 +45,7 @@ class SyntaxElement:
                     try:
                         replacement = match.group(variable_match.group('varname'))
                     except:
-                        print "Group %s is not defined in pattern" % variable_match.group('varname')
+                        print("Group %s is not defined in pattern" % variable_match.group('varname'))
                         replacement = variable_match.group('varname')
                     try:
                         closingline = closingline.replace(variable_match.group(0), replacement)

--- a/ftplugin/fortran_make.vim
+++ b/ftplugin/fortran_make.vim
@@ -240,7 +240,7 @@ for sdirs in dlsts:
           mak.write("endif\n")
           mak.write(binname+"_LDADD = \nEXTRA_DIST= \nCLEANFILES =*.mod,*.o")
 if os.path.isfile(ofn):
-  print "File "+ofn+" created. Check it before proceed."
+  print("File "+ofn+" created. Check it before proceed.")
 EOF
 endfunction
 


### PR DESCRIPTION
All it's needed is the print function, so this works fine. I didn't add
`from __future__ import print_function` because it's really not needed.