### PR TITLE
mute the message from fortran_maps.vim when "Last Modified" is not found

### DIFF
--- a/ftplugin/fortran_maps.vim
+++ b/ftplugin/fortran_maps.vim
@@ -47,4 +47,4 @@ exe 'noremap'  b:fortran_cla      ': call CLArgs()<CR>'
 exe 'noremap'  b:fortran_genProj  ': call MakeProject()<CR>'
 " nnoremap    <leader>cl      :call Link()<CR>
 
-autocmd Bufwritepre,filewritepre *.f90 silent! execute "%g/Last Modified:.*/s/Last Modified:.*/Last Modified: " .strftime("%c")
+autocmd Bufwritepre,filewritepre *.f90 let curpos = getpos('.') | silent! execute "%g/Last Modified:.*/s/Last Modified:.*/Last Modified: " .strftime("%c") | call setpos('.', curpos)

--- a/ftplugin/fortran_maps.vim
+++ b/ftplugin/fortran_maps.vim
@@ -1,9 +1,9 @@
 "########################################################################
 " File: fortran_maps.vim
-" Author: Rudra Banerjee (bnrj DOT rudra at gmail.com) 
+" Author: Rudra Banerjee (bnrj DOT rudra at gmail.com)
 " Version: 0.2
 " Copyright: Copyright (C) 2019 Rudra Banerjee
-" 
+"
 "    This program is free software: you can redistribute it and/or modify
 "    it under the terms of the GNU General Public License as published by
 "    the Free Software Foundation, either version 3 of the License, or
@@ -14,7 +14,7 @@
 "    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 "    GNU General Public License for more details.
 "
-" Description: Mappings! This file do not contain any new program. 
+" Description: Mappings! This file do not contain any new program.
 " It just calls functions defined in other fils.
 "########################################################################
 
@@ -47,4 +47,4 @@ exe 'noremap'  b:fortran_cla      ': call CLArgs()<CR>'
 exe 'noremap'  b:fortran_genProj  ': call MakeProject()<CR>'
 " nnoremap    <leader>cl      :call Link()<CR>
 
-autocmd Bufwritepre,filewritepre *.f90 exe "%g/Last Modified:.*/s/Last Modified:.*/Last Modified: " .strftime("%c")
+autocmd Bufwritepre,filewritepre *.f90 silent! execute "%g/Last Modified:.*/s/Last Modified:.*/Last Modified: " .strftime("%c")


### PR DESCRIPTION
Currently, a message will pop out if "Last Modified"  is not found by fortran_maps. It might be a good idea to mute it. 

Thank you for your consideration. 